### PR TITLE
Clue Trainer URL

### DIFF
--- a/commands/scantrainer.txt
+++ b/commands/scantrainer.txt
@@ -1,7 +1,7 @@
 {
   "embed": {
     "title": "__Clue Trainer__ <:cluescroll:1037463867716018206>",
-    "description": "Clue Trainer (formerly Scan Trainer and currently work-in-progress) is a new and feature-rich clue solver for Alt1 developed by <@338283681120780288>. It not only shows you where to go, but also how to efficiently get there using movement abilities. It includes an improved puzzle solver that allows you to go at your own pace.\n\nThe current in-development preview can already be used **[here](<https://leridon.github.io/rs3scantrainer/>)**.\nA more detailled explanation and FAQ can be found in <#1240372943725531339>\n For discussion and support visit <#1103737270114209825>\n\n An installation guide on Alt1Toolkit & Clue Trainer can be found **[here](<https://www.youtube.com/watch?v=OWFgy66klf4>)**.",
+    "description": "Clue Trainer (formerly Scan Trainer and currently work-in-progress) is a new and feature-rich clue solver for Alt1 developed by <@338283681120780288>. It not only shows you where to go, but also how to efficiently get there using movement abilities. It includes an improved puzzle solver that allows you to go at your own pace.\n\nThe current in-development preview can already be used **[here](<https://cluetrainer.app>)**.\nA more detailled explanation and FAQ can be found in <#1240372943725531339>\n For discussion and support visit <#1103737270114209825>\n\n An installation guide on Alt1Toolkit & Clue Trainer can be found **[here](<https://www.youtube.com/watch?v=OWFgy66klf4>)**.",
     "color": 12745742,
     "fields": []
   }

--- a/infohub/faq-and-misc/alt1-overview-and-plugins.txt
+++ b/infohub/faq-and-misc/alt1-overview-and-plugins.txt
@@ -51,7 +51,7 @@ In addition to the default apps that come with Alt1, there are a number of other
 .tag:linuxmac
 While official Alt1 support is not offered for these operating systems, there's an alternative plugin designed for macOS called [RuneKit](https://github.com/whs/runekit), which you might find beneficial to explore.
 .
-### > __**Clue Trainer**__ - `alt1://addapp/https://leridon.github.io/rs3scantrainer/appconfig.json `
+### > __**Clue Trainer**__ - `alt1://addapp/https://cluetrainer.app/appconfig.json `
 .tag:cluetrainer
 **Explanation** - An alternative, fully featured clue solver featuring improved puzzle solvers and recommendations for efficient movement. A more detailled explanation and FAQ can be found in <#1240372943725531339>
 

--- a/infohub/solving-clues/clue-trainer.txt
+++ b/infohub/solving-clues/clue-trainer.txt
@@ -1,6 +1,6 @@
 **__Clue Trainer__** *(courtesy of <@338283681120780288>)*
 .tag:start
-To get started quickly, jump into Clue Trainer by visiting the [Web Version](https://leridon.github.io/rs3scantrainer), where you can also find the installation link for Alt1.
+To get started quickly, jump into Clue Trainer by visiting the [Web Version](https://cluetrainer.app), where you can also find the installation link for Alt1.
 .img:https://raw.githubusercontent.com/Clue-Chasers/cc-master/main/files/image1.png
 
 .
@@ -34,7 +34,7 @@ Clue Trainer originally started as "Scan Trainer" an was intended to be an inter
 __**FAQ**__
 .tag:faq
 **⬥ How do I install Clue Trainer?**
-The [Web Version](https://leridon.github.io/rs3scantrainer/) includes links to install Clue Trainer with one click as shown below.
+The [Web Version](https://cluetrainer.app) includes links to install Clue Trainer with one click as shown below.
 
 .img:https://raw.githubusercontent.com/Clue-Chasers/cc-master/main/files/image2.png
 


### PR DESCRIPTION
Updates the url for cluetrainer from leridon.github.io/rs3scantrainer to the new custom domain cluetrainer.app